### PR TITLE
wrong firmware types

### DIFF
--- a/application/inc/lr1120_transceiver_0201.h
+++ b/application/inc/lr1120_transceiver_0201.h
@@ -60,7 +60,7 @@
 /*!
  * \brief Firmware type
  */
-#define LR11XX_FIRMWARE_UPDATE_TO LR1110_FIRMWARE_UPDATE_TO_TRX
+#define LR11XX_FIRMWARE_UPDATE_TO LR1120_FIRMWARE_UPDATE_TO_TRX
 
 /*!
  * \brief Array containing the firmware image

--- a/application/inc/lr1121_transceiver_0103.h
+++ b/application/inc/lr1121_transceiver_0103.h
@@ -60,7 +60,7 @@
 /*!
  * \brief Firmware type
  */
-#define LR11XX_FIRMWARE_UPDATE_TO LR1110_FIRMWARE_UPDATE_TO_TRX
+#define LR11XX_FIRMWARE_UPDATE_TO LR1121_FIRMWARE_UPDATE_TO_TRX
 
 /*!
  * \brief Array containing the firmware image


### PR DESCRIPTION
there is an issue: in `lr1120_transceiver_0201.h` and `lr1121_transceiver_0103.h` was wrong firmware types. So update was always failed. Fixed it and checked. Successfully updated my lr1121